### PR TITLE
.github, tools: add basic CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,26 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: cargo fmt
+      run: cargo fmt -- --check --verbose
+    - name: Clippy
+      run: cargo clippy -- -D warnings
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/tools/pre-push
+++ b/tools/pre-push
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Create a symlink from `.git/pre-push` to this script to run the checks below
+# before pushing changes to github.  This will avoid CI failures due to clippy
+# lints and formatting issues.
+
+echo "Checking Rust rules prior to push.  To run this check by hand invoke 'tools/prepush.sh'"
+
+set -e
+
+cargo fmt -- --check
+cargo clippy -- -D warnings


### PR DESCRIPTION
This adds basic CI in a workflow and accompanying pre-push scripts.