### PR TITLE
lib: remove default code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,1 @@
 mod address;
-
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}


### PR DESCRIPTION
This PR removes the default code in a new library crate.